### PR TITLE
feat: add OpenAI-compatible API configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,1 +1,8 @@
 OPENAI_API_KEY=your_api_key
+OPENAI_BASE_URL=https://api.openai.com/v1
+REALTIME_MODEL=gpt-4o-realtime-preview-2025-06-03
+OPENAI_ADDITIONAL_HEADERS={}
+NEXT_PUBLIC_OPENAI_BASE_URL=https://api.openai.com/v1
+NEXT_PUBLIC_REALTIME_MODEL=gpt-4o-realtime-preview-2025-06-03
+NEXT_PUBLIC_TRANSCRIPTION_MODEL=gpt-4o-mini-transcribe
+NEXT_PUBLIC_TEXT_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@ There are two main patterns demonstrated:
 
 - This is a Next.js typescript app. Install dependencies with `npm i`.
 - Add your `OPENAI_API_KEY` to your env. Either add it to your `.bash_profile` or equivalent, or copy `.env.sample` to `.env` and add it there.
+- To use OpenAI-compatible services (OpenRouter, Ollama, LM Studio, etc.) set `OPENAI_BASE_URL` and `NEXT_PUBLIC_OPENAI_BASE_URL` to the provider's base URL and, if required, add extra headers in `OPENAI_ADDITIONAL_HEADERS` (JSON format). You can also override models with `REALTIME_MODEL`, `NEXT_PUBLIC_REALTIME_MODEL`, `NEXT_PUBLIC_TRANSCRIPTION_MODEL`, and `NEXT_PUBLIC_TEXT_MODEL`.
 - Start the server with `npm run dev`
 - Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
 - You can change examples via the "Scenario" dropdown in the top right.
+
+### Using OpenAI-Compatible APIs
+
+This project can connect to any service that implements the OpenAI API.
+To target providers like **OpenRouter**, **Ollama**, or **LM Studio**:
+
+- Set `OPENAI_BASE_URL` and `NEXT_PUBLIC_OPENAI_BASE_URL` to the provider's base URL (e.g. `https://openrouter.ai/api/v1`, `http://localhost:11434/v1`).
+- Provide any required custom headers via `OPENAI_ADDITIONAL_HEADERS` as a JSON object.
+- Override model names with `REALTIME_MODEL`, `NEXT_PUBLIC_REALTIME_MODEL`, `NEXT_PUBLIC_TRANSCRIPTION_MODEL`, and `NEXT_PUBLIC_TEXT_MODEL` as needed.
 
 # Agentic Pattern 1: Chat-Supervisor
 

--- a/src/app/agentConfigs/customerServiceRetail/returns.ts
+++ b/src/app/agentConfigs/customerServiceRetail/returns.ts
@@ -88,8 +88,8 @@ Speak at a medium pace—steady and clear. Brief pauses can be used for emphasis
         required: ['phoneNumber'],
         additionalProperties: false,
       },
-      execute: async (input: any) => {
-        const { phoneNumber } = input as { phoneNumber: string };
+      execute: async ({ phoneNumber }: { phoneNumber: string }) => {
+        void phoneNumber;
         return {
           orders: [
             {
@@ -160,7 +160,7 @@ Speak at a medium pace—steady and clear. Brief pauses can be used for emphasis
         required: ['region', 'itemCategory'],
         additionalProperties: false,
       },
-      execute: async (input: any) => {
+      execute: async () => {
         return {
           policy: `
 At Snowy Peak Boards, we believe in transparent and customer-friendly policies to ensure you have a hassle-free experience. Below are our detailed guidelines:

--- a/src/app/agentConfigs/customerServiceRetail/sales.ts
+++ b/src/app/agentConfigs/customerServiceRetail/sales.ts
@@ -64,7 +64,7 @@ export const salesAgent = new RealtimeAgent({
         required: ['item_id'],
         additionalProperties: false,
       },
-      execute: async (input: any) => ({ success: true }),
+      execute: async () => ({ success: true }),
     }),
 
     tool({
@@ -90,7 +90,7 @@ export const salesAgent = new RealtimeAgent({
         required: ['item_ids', 'phone_number'],
         additionalProperties: false,
       },
-      execute: async (input: any) => ({ checkoutUrl: 'https://example.com/checkout' }),
+      execute: async () => ({ checkoutUrl: 'https://example.com/checkout' }),
     }),
   ],
 

--- a/src/app/agentConfigs/guardrails.ts
+++ b/src/app/agentConfigs/guardrails.ts
@@ -38,7 +38,7 @@ export async function runGuardrailClassifier(
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      model: 'gpt-4o-mini',
+      model: process.env.NEXT_PUBLIC_TEXT_MODEL ?? 'gpt-4o-mini',
       input: messages,
       text: {
         format: zodTextFormat(GuardrailOutputZod, 'output_format'),

--- a/src/app/api/responses/route.ts
+++ b/src/app/api/responses/route.ts
@@ -5,7 +5,20 @@ import OpenAI from 'openai';
 export async function POST(req: NextRequest) {
   const body = await req.json();
 
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  let extraHeaders: Record<string, string> | undefined;
+  if (process.env.OPENAI_ADDITIONAL_HEADERS) {
+    try {
+      extraHeaders = JSON.parse(process.env.OPENAI_ADDITIONAL_HEADERS);
+    } catch (e) {
+      console.warn('Failed to parse OPENAI_ADDITIONAL_HEADERS', e);
+    }
+  }
+
+  const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: process.env.OPENAI_BASE_URL,
+    defaultHeaders: extraHeaders,
+  });
 
   if (body.text?.format?.type === 'json_schema') {
     return await structuredResponse(openai, body);

--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -2,19 +2,31 @@ import { NextResponse } from "next/server";
 
 export async function GET() {
   try {
-    const response = await fetch(
-      "https://api.openai.com/v1/realtime/sessions",
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "gpt-4o-realtime-preview-2025-06-03",
-        }),
+    const baseUrl =
+      process.env.OPENAI_BASE_URL ?? "https://api.openai.com/v1";
+
+    let extraHeaders: Record<string, string> = {};
+    if (process.env.OPENAI_ADDITIONAL_HEADERS) {
+      try {
+        extraHeaders = JSON.parse(process.env.OPENAI_ADDITIONAL_HEADERS);
+      } catch (e) {
+        console.warn("Failed to parse OPENAI_ADDITIONAL_HEADERS", e);
       }
-    );
+    }
+
+    const response = await fetch(`${baseUrl}/realtime/sessions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+        ...extraHeaders,
+      },
+      body: JSON.stringify({
+        model:
+          process.env.REALTIME_MODEL ??
+          "gpt-4o-realtime-preview-2025-06-03",
+      }),
+    });
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {

--- a/src/app/hooks/useRealtimeSession.ts
+++ b/src/app/hooks/useRealtimeSession.ts
@@ -128,21 +128,32 @@ export function useRealtimeSession(callbacks: RealtimeSessionCallbacks = {}) {
       const codecParam = codecParamRef.current;
       const audioFormat = audioFormatForCodec(codecParam);
 
+      const realtimeModel =
+        process.env.NEXT_PUBLIC_REALTIME_MODEL ??
+        'gpt-4o-realtime-preview-2025-06-03';
+      const transcriptionModel =
+        process.env.NEXT_PUBLIC_TRANSCRIPTION_MODEL ??
+        'gpt-4o-mini-transcribe';
+      const baseUrl = process.env.NEXT_PUBLIC_OPENAI_BASE_URL
+        ? `${process.env.NEXT_PUBLIC_OPENAI_BASE_URL}/realtime`
+        : undefined;
+
       sessionRef.current = new RealtimeSession(rootAgent, {
         transport: new OpenAIRealtimeWebRTC({
           audioElement,
+          baseUrl,
           // Set preferred codec before offer creation
           changePeerConnection: async (pc: RTCPeerConnection) => {
             applyCodec(pc);
             return pc;
           },
         }),
-        model: 'gpt-4o-realtime-preview-2025-06-03',
+        model: realtimeModel,
         config: {
           inputAudioFormat: audioFormat,
           outputAudioFormat: audioFormat,
           inputAudioTranscription: {
-            model: 'gpt-4o-mini-transcribe',
+            model: transcriptionModel,
           },
         },
         outputGuardrails: outputGuardrails ?? [],


### PR DESCRIPTION
## Summary
- allow configuring base URLs and extra headers for OpenAI-compatible providers
- enable client and server models to be overridden via env vars
- document OpenAI-compatible setup and tidy unused variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895c839bc108328b7a216721678a54c